### PR TITLE
support for H740P Enhanced HBA mode in dracclient

### DIFF
--- a/dracclient/client.py
+++ b/dracclient/client.py
@@ -753,11 +753,9 @@ class DRACClient(object):
         """
         return self._raid_mgmt.list_raid_controllers()
 
-    def list_raid_controller_settings(self, by_name=False):
+    def list_raid_controller_settings(self):
         """List the RAID configuration settings
 
-        :param by_name: Controls whether returned dictionary uses RAID
-                        attribute name or instance_id as key.
         :returns: a dictionary with the RAID settings using InstanceID as the
                   key. The attributes are either RAIDEnumerableAttribute,
                   RAIDStringAttribute objects.
@@ -766,7 +764,7 @@ class DRACClient(object):
         :raises: DRACOperationFailed on error reported back by the DRAC
                  interface
         """
-        return self._raid_mgmt.list_raid_controller_settings(by_name)
+        return self._raid_mgmt.list_raid_controller_settings()
 
     def set_raid_controller_settings(self, settings, raid_fqdd):
         """Sets the RAID configuration
@@ -793,7 +791,7 @@ class DRACClient(object):
         return self._raid_mgmt.set_raid_controller_settings(settings,
                                                             raid_fqdd)
 
-    def get_raid_controller_mode(self):
+    def get_raid_controller_mode(self, raid_fqdd):
         """Returns the current RAID controller mode
 
         :returns: the current RAID controller mode
@@ -802,7 +800,7 @@ class DRACClient(object):
         :raises: DRACOperationFailed on error reported back by the DRAC
                  interface
         """
-        return self._raid_mgmt.get_raid_controller_mode()
+        return self._raid_mgmt.get_raid_controller_mode(raid_fqdd)
 
     def list_virtual_disks(self):
         """Returns the list of RAID arrays

--- a/dracclient/client.py
+++ b/dracclient/client.py
@@ -777,7 +777,7 @@ class DRACClient(object):
         :param settings: a dictionary containing the proposed values, with
                          each key being the name of attribute and the value
                          being the proposed value.
-        :param raid_fqdd: the FQDD of the RAID.
+        :param raid_fqdd: the FQDD of the RAID controller.
         :returns: a dictionary containing:
                  - The is_commit_required key with a boolean value indicating
                    whether a config job must be created for the values to be
@@ -796,7 +796,7 @@ class DRACClient(object):
     def get_raid_controller_mode(self):
         """Returns the current RAID controller mode
 
-        :returns: the current RAIDController mode
+        :returns: the current RAID controller mode
         :raises: WSManRequestFailure on request failures
         :raises: WSManInvalidResponse when receiving invalid response
         :raises: DRACOperationFailed on error reported back by the DRAC

--- a/dracclient/client.py
+++ b/dracclient/client.py
@@ -753,7 +753,7 @@ class DRACClient(object):
         """
         return self._raid_mgmt.list_raid_controllers()
 
-    def list_raid_cntrl_settings(self, by_name=False):
+    def list_raid_controller_settings(self, by_name=False):
         """List the RAID configuration settings
 
         :param by_name: Controls whether returned dictionary uses RAID
@@ -766,9 +766,9 @@ class DRACClient(object):
         :raises: DRACOperationFailed on error reported back by the DRAC
                  interface
         """
-        return self._raid_mgmt.list_raid_cntrl_settings(by_name)
+        return self._raid_mgmt.list_raid_controller_settings(by_name)
 
-    def set_raid_cntrl_settings(self, settings, raid_fqdd):
+    def set_raid_controller_settings(self, settings, raid_fqdd):
         """Sets the RAID configuration
 
         It sets the pending_value parameter for each of the attributes
@@ -777,6 +777,7 @@ class DRACClient(object):
         :param settings: a dictionary containing the proposed values, with
                          each key being the name of attribute and the value
                          being the proposed value.
+        :param raid_fqdd: the FQDD of the RAID.
         :returns: a dictionary containing:
                  - The is_commit_required key with a boolean value indicating
                    whether a config job must be created for the values to be
@@ -789,7 +790,8 @@ class DRACClient(object):
         :raises: DRACOperationFailed on error reported back by the DRAC
                  interface
         """
-        return self._raid_mgmt.set_raid_cntrl_settings(settings, raid_fqdd)
+        return self._raid_mgmt.set_raid_controller_settings(settings,
+                                                            raid_fqdd)
 
     def get_raid_controller_mode(self):
         """Returns the current RAID controller mode

--- a/dracclient/client.py
+++ b/dracclient/client.py
@@ -753,6 +753,55 @@ class DRACClient(object):
         """
         return self._raid_mgmt.list_raid_controllers()
 
+    def list_raid_cntrl_settings(self, by_name=False):
+        """List the RAID configuration settings
+
+        :param by_name: Controls whether returned dictionary uses RAID
+                        attribute name or instance_id as key.
+        :returns: a dictionary with the RAID settings using InstanceID as the
+                  key. The attributes are either RAIDEnumerableAttribute,
+                  RAIDStringAttribute objects.
+        :raises: WSManRequestFailure on request failures
+        :raises: WSManInvalidResponse when receiving invalid response
+        :raises: DRACOperationFailed on error reported back by the DRAC
+                 interface
+        """
+        return self._raid_mgmt.list_raid_cntrl_settings(by_name)
+
+    def set_raid_cntrl_settings(self, settings, raid_fqdd):
+        """Sets the RAID configuration
+
+        It sets the pending_value parameter for each of the attributes
+        passed in. For the values to be applied, a config job must
+        be created.
+        :param settings: a dictionary containing the proposed values, with
+                         each key being the name of attribute and the value
+                         being the proposed value.
+        :returns: a dictionary containing:
+                 - The is_commit_required key with a boolean value indicating
+                   whether a config job must be created for the values to be
+                   applied.
+                 - The is_reboot_required key with a RebootRequired enumerated
+                   value indicating whether the server must be rebooted for the
+                   values to be applied. Possible values are true and false.
+        :raises: WSManRequestFailure on request failures
+        :raises: WSManInvalidResponse when receiving invalid response
+        :raises: DRACOperationFailed on error reported back by the DRAC
+                 interface
+        """
+        return self._raid_mgmt.set_raid_cntrl_settings(settings, raid_fqdd)
+
+    def get_raid_controller_mode(self):
+        """Returns the current RAID controller mode
+
+        :returns: the current RAIDController mode
+        :raises: WSManRequestFailure on request failures
+        :raises: WSManInvalidResponse when receiving invalid response
+        :raises: DRACOperationFailed on error reported back by the DRAC
+                 interface
+        """
+        return self._raid_mgmt.get_raid_controller_mode()
+
     def list_virtual_disks(self):
         """Returns the list of RAID arrays
 

--- a/dracclient/resources/raid.py
+++ b/dracclient/resources/raid.py
@@ -133,10 +133,9 @@ class RAIDAttribute(object):
             raid_attr_xml, namespace, 'AttributeName')
         instance_id = utils.get_wsman_resource_attr(
             raid_attr_xml, namespace, 'InstanceID')
-        current_value = [attr.text for attr
-                           in utils.find_xml(raid_attr_xml,
-                                             'CurrentValue',
-                                             namespace, find_all=True)]
+        current_value = [attr.text for attr in
+                         utils.find_xml(raid_attr_xml, 'CurrentValue',
+                                        namespace, find_all=True)]
         pending_value = utils.get_wsman_resource_attr(
             raid_attr_xml, namespace, 'PendingValue', nullable=True)
         read_only = utils.get_wsman_resource_attr(
@@ -256,10 +255,11 @@ class RAIDIntegerAttribute(RAIDAttribute):
 
         :param name: name of the RAID attribute
         :param instance_id: InstanceID of the RAID attribute
-        :param current_value: list containing the current value of the RAID
-		attribute
+        :param current_value: list containing the current value of the
+                RAID attribute
         :param pending_value: pending value of the RAID attribute,
-                reflecting an unprocessed change (eg. config job not completed)
+                reflecting an unprocessed change
+                (eg. config job not completed)
         :param read_only: indicates whether this RAID attribute can be
                 changed
         :param fqdd: Fully Qualified Device Description of the RAID
@@ -273,7 +273,6 @@ class RAIDIntegerAttribute(RAIDAttribute):
                                                    read_only, fqdd)
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
-
 
     @classmethod
     def parse(cls, raid_attr_xml):
@@ -382,7 +381,8 @@ class RAIDManagement(object):
         """
         raid_cntrl_attr = self.list_raid_controller_settings()
 
-        raid_cntrl_mode = raid_cntrl_attr.get('{}:RAIDCurrentControllerMode'.format(raid_fqdd))
+        raid_cntrl_mode = raid_cntrl_attr.get(
+            '{}:RAIDCurrentControllerMode'.format(raid_fqdd))
 
         return raid_cntrl_mode.current_value[0]
 

--- a/dracclient/resources/raid.py
+++ b/dracclient/resources/raid.py
@@ -322,11 +322,9 @@ class RAIDManagement(object):
         """
         self.client = client
 
-    def list_raid_controller_settings(self, by_name=False):
+    def list_raid_controller_settings(self):
         """List the RAID configuration settings
 
-        :param by_name: Controls whether returned dictionary uses RAID
-                        attribute name or instance_id as key.
         :returns: a dictionary with the RAID settings using InstanceID as the
                   key. The attributes are either RAIDEnumerableAttribute,
                   RAIDStringAttribute objects.
@@ -337,7 +335,7 @@ class RAIDManagement(object):
         """
 
         return utils.list_settings(self.client, self.NAMESPACES,
-                                   by_name=by_name)
+                                   by_name=False)
 
     def set_raid_controller_settings(self, new_settings, raid_fqdd):
         """Sets the RAID configuration
@@ -372,18 +370,19 @@ class RAIDManagement(object):
                                   raid_fqdd,
                                   by_name=False)
 
-    def get_raid_controller_mode(self):
+    def get_raid_controller_mode(self, raid_fqdd):
         """Returns the current RAID controller mode
 
+        :param raid_fqdd: the FQDD of the RAID controller.
         :returns: the current RAID controller mode
         :raises: WSManRequestFailure on request failures
         :raises: WSManInvalidResponse when receiving invalid response
         :raises: DRACOperationFailed on error reported back by the DRAC
                  interface
         """
-        raid_cntrl_attr = self.list_raid_controller_settings(by_name=True)
+        raid_cntrl_attr = self.list_raid_controller_settings()
 
-        raid_cntrl_mode = raid_cntrl_attr.get('RAIDCurrentControllerMode')
+        raid_cntrl_mode = raid_cntrl_attr.get('{}:RAIDCurrentControllerMode'.format(raid_fqdd))
 
         return raid_cntrl_mode.current_value[0]
 

--- a/dracclient/resources/raid.py
+++ b/dracclient/resources/raid.py
@@ -98,7 +98,150 @@ VirtualDisk = collections.namedtuple(
 NO_FOREIGN_DRIVE = "STOR018"
 
 
+class RAIDAttribute(object):
+    """Generic RAID attribute class"""
+
+    def __init__(self, name, instance_id, current_value, pending_value,
+                 read_only, fqdd):
+        """Creates RAIDAttribute object
+
+        :param name: name of the RAID attribute
+        :param instance_id: InstanceID of the RAID attribute
+        :param current_value: current value of the RAID attribute
+        :param pending_value: pending value of the RAID attribute, reflecting
+                an unprocessed change (eg. config job not completed)
+        :param read_only: indicates whether this RAID attribute can be changed
+        :param fqdd: Fully Qualified Device Description of the RAID Attribute
+        """
+
+        self.name = name
+        self.instance_id = instance_id
+        self.current_value = current_value
+        self.pending_value = pending_value
+        self.read_only = read_only
+        self.fqdd = fqdd
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+    @classmethod
+    def parse(cls, namespace, raid_attr_xml):
+        """Parses XML and creates RAIDAttribute object"""
+
+        name = utils.get_wsman_resource_attr(
+            raid_attr_xml, namespace, 'AttributeName')
+        instance_id = utils.get_wsman_resource_attr(
+            raid_attr_xml, namespace, 'InstanceID')
+        current_value = utils.get_wsman_resource_attr(
+            raid_attr_xml, namespace, 'CurrentValue', nullable=True)
+        pending_value = utils.get_wsman_resource_attr(
+            raid_attr_xml, namespace, 'PendingValue', nullable=True)
+        read_only = utils.get_wsman_resource_attr(
+            raid_attr_xml, namespace, 'IsReadOnly')
+        fqdd = utils.get_wsman_resource_attr(
+            raid_attr_xml, namespace, 'FQDD')
+
+        return cls(name, instance_id, current_value, pending_value,
+                   (read_only == 'true'), fqdd)
+
+
+class RAIDEnumerableAttribute(RAIDAttribute):
+    """Enumerable RAID attribute class"""
+
+    namespace = uris.DCIM_RAIDEnumeration
+
+    def __init__(self, name, instance_id, current_value, pending_value,
+                 read_only, fqdd, possible_values):
+        """Creates RAIDEnumerableAttribute object
+
+        :param name: name of the RAID attribute
+        :param current_value: current value of the RAID attribute
+        :param pending_value: pending value of the RAID attribute, reflecting
+                an unprocessed change (eg. config job not completed)
+        :param read_only: indicates whether this RAID attribute can be changed
+        :param fqdd: Fully Qualified Device Description of the RAID
+                Attribute
+        :param possible_values: list containing the allowed values for the RAID
+                attribute
+        """
+        super(RAIDEnumerableAttribute, self).__init__(name, instance_id,
+                                                      current_value,
+                                                      pending_value,
+                                                      read_only, fqdd)
+        self.possible_values = possible_values
+
+    @classmethod
+    def parse(cls, raid_attr_xml):
+        """Parses XML and creates RAIDEnumerableAttribute object"""
+
+        raid_attr = RAIDAttribute.parse(cls.namespace, raid_attr_xml)
+        possible_values = [attr.text for attr
+                           in utils.find_xml(raid_attr_xml,
+                                             'PossibleValues',
+                                             cls.namespace, find_all=True)]
+
+        return cls(raid_attr.name, raid_attr.instance_id,
+                   raid_attr.current_value, raid_attr.pending_value,
+                   raid_attr.read_only, raid_attr.fqdd, possible_values)
+
+    def validate(self, new_value):
+        """Validates new value"""
+
+        if str(new_value) not in self.possible_values:
+            msg = ("Attribute '%(attr)s' cannot be set to value '%(val)s'."
+                   " It must be in %(possible_values)r.") % {
+                       'attr': self.name,
+                       'val': new_value,
+                       'possible_values': self.possible_values}
+            return msg
+
+
+class RAIDStringAttribute(RAIDAttribute):
+    """String RAID attribute class"""
+
+    namespace = uris.DCIM_RAIDString
+
+    def __init__(self, name, instance_id, current_value, pending_value,
+                 read_only, fqdd, min_length, max_length):
+        """Creates RAIDStringAttribute object
+
+        :param name: name of the RAID attribute
+        :param instance_id: InstanceID of the RAID attribute
+        :param current_value: current value of the RAID attribute
+        :param pending_value: pending value of the RAID attribute, reflecting
+                an unprocessed change (eg. config job not completed)
+        :param read_only: indicates whether this RAID attribute can be changed
+        :param fqdd: Fully Qualified Device Description of the RAID
+                Attribute
+        :param min_length: minimum length of the string
+        :param max_length: maximum length of the string
+        """
+        super(RAIDStringAttribute, self).__init__(name, instance_id,
+                                                  current_value,
+                                                  pending_value,
+                                                  read_only, fqdd)
+        self.min_length = min_length
+        self.max_length = max_length
+
+    @classmethod
+    def parse(cls, raid_attr_xml):
+        """Parses XML and creates RAIDStringAttribute object"""
+
+        raid_attr = RAIDAttribute.parse(cls.namespace, raid_attr_xml)
+        min_length = int(utils.get_wsman_resource_attr(
+            raid_attr_xml, cls.namespace, 'MinLength'))
+        max_length = int(utils.get_wsman_resource_attr(
+            raid_attr_xml, cls.namespace, 'MaxLength'))
+
+        return cls(raid_attr.name, raid_attr.instance_id,
+                   raid_attr.current_value, raid_attr.pending_value,
+                   raid_attr.read_only, raid_attr.fqdd, min_length, max_length)
+
+
 class RAIDManagement(object):
+
+    NAMESPACES = [(uris.DCIM_RAIDEnumeration, RAIDEnumerableAttribute),
+                  (uris.DCIM_RAIDString, RAIDStringAttribute)]
 
     def __init__(self, client):
         """Creates RAIDManagement object
@@ -106,6 +249,68 @@ class RAIDManagement(object):
         :param client: an instance of WSManClient
         """
         self.client = client
+
+    def list_raid_cntrl_settings(self, by_name=False):
+        """List the RAID configuration settings
+
+        :param by_name: Controls whether returned dictionary uses RAID
+                        attribute name or instance_id as key.
+        :returns: a dictionary with the RAID settings using InstanceID as the
+                  key. The attributes are either RAIDEnumerableAttribute,
+                  RAIDStringAttribute objects.
+        :raises: WSManRequestFailure on request failures
+        :raises: WSManInvalidResponse when receiving invalid response
+        :raises: DRACOperationFailed on error reported back by the DRAC
+                interface
+        """
+
+        return utils.list_settings(self.client, self.NAMESPACES, by_name)
+
+    def set_raid_cntrl_settings(self, new_settings, raid_fqdd):
+        """Sets the RAID configuration
+
+        It sets the pending_value parameter for each of the attributes
+        passed in. For the values to be applied, a config job must
+        be created.
+        :param settings: a dictionary containing the proposed values, with
+                         each key being the name of attribute and the value
+                         being the proposed value.
+        :returns: a dictionary containing:
+                 - The is_commit_required key with a boolean value indicating
+                   whether a config job must be created for the values to be
+                   applied.
+                 - The is_reboot_required key with a RebootRequired enumerated
+                   value indicating whether the server must be rebooted for the
+                   values to be applied. Possible values are true and false.
+        :raises: WSManRequestFailure on request failures
+        :raises: WSManInvalidResponse when receiving invalid response
+        :raises: DRACOperationFailed on error reported back by the DRAC
+                interface
+        """
+
+        return utils.set_settings('RAID',
+                                  self.client,
+                                  self.NAMESPACES,
+                                  new_settings,
+                                  uris.DCIM_RAIDService,
+                                  "DCIM_RAIDService",
+                                  "DCIM:RAIDService",
+                                  raid_fqdd)
+
+    def get_raid_controller_mode(self):
+        """Returns the current RAID controller mode
+
+        :returns: the current RAIDController mode
+        :raises: WSManRequestFailure on request failures
+        :raises: WSManInvalidResponse when receiving invalid response
+        :raises: DRACOperationFailed on error reported back by the DRAC
+                 interface
+        """
+        raid_cntrl_attr = self.list_raid_cntrl_settings(by_name=True)
+
+        raid_cntrl_mode = raid_cntrl_attr.get('RAIDCurrentControllerMode')
+
+        return raid_cntrl_mode.current_value
 
     def list_raid_controllers(self):
         """Returns the list of RAID controllers

--- a/dracclient/resources/uris.py
+++ b/dracclient/resources/uris.py
@@ -13,7 +13,7 @@
 
 """
 Schema definitions and resource URIs for the classes implemented by the DRAC
-WS-Man API.DCIM_RAIDEnumeration
+WS-Man API.
 """
 
 DCIM_BIOSEnumeration = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'

--- a/dracclient/resources/uris.py
+++ b/dracclient/resources/uris.py
@@ -97,6 +97,12 @@ DCIM_PhysicalDiskView = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
 DCIM_RAIDService = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
                     'DCIM_RAIDService')
 
+DCIM_RAIDEnumeration = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
+                        'DCIM_RAIDEnumeration')
+
+DCIM_RAIDString = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
+                   'DCIM_RAIDString')
+
 DCIM_SystemView = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
                    'DCIM_SystemView')
 

--- a/dracclient/resources/uris.py
+++ b/dracclient/resources/uris.py
@@ -104,7 +104,7 @@ DCIM_RAIDString = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
                    'DCIM_RAIDString')
 
 DCIM_RAIDInteger = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
-                   'DCIM_RAIDInteger')
+                    'DCIM_RAIDInteger')
 
 DCIM_SystemView = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
                    'DCIM_SystemView')

--- a/dracclient/resources/uris.py
+++ b/dracclient/resources/uris.py
@@ -13,7 +13,7 @@
 
 """
 Schema definitions and resource URIs for the classes implemented by the DRAC
-WS-Man API.
+WS-Man API.DCIM_RAIDEnumeration
 """
 
 DCIM_BIOSEnumeration = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
@@ -102,6 +102,9 @@ DCIM_RAIDEnumeration = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
 
 DCIM_RAIDString = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
                    'DCIM_RAIDString')
+
+DCIM_RAIDInteger = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
+                   'DCIM_RAIDInteger')
 
 DCIM_SystemView = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
                    'DCIM_SystemView')

--- a/dracclient/tests/test_raid.py
+++ b/dracclient/tests/test_raid.py
@@ -189,7 +189,9 @@ class ClientRAIDManagementTestCase(base.BaseTest):
             {'text': test_utils.RAIDEnumerations[
                 uris.DCIM_RAIDEnumeration]['ok']},
             {'text': test_utils.RAIDEnumerations[
-                uris.DCIM_RAIDString]['ok']}])
+                uris.DCIM_RAIDString]['ok']},
+            {'text': test_utils.RAIDEnumerations[
+                uris.DCIM_RAIDInteger]['ok']}])
         mock_get_raid_controller_mode.return_value = "RAID"
         raid_cntrl_mode = self.drac_client.get_raid_controller_mode(
             self.raid_controller_fqdd)

--- a/dracclient/tests/test_raid.py
+++ b/dracclient/tests/test_raid.py
@@ -116,14 +116,14 @@ class ClientRAIDManagementTestCase(base.BaseTest):
     @mock.patch.object(dracclient.client.WSManClient,
                        'wait_until_idrac_is_ready', spec_set=True,
                        autospec=True)
-    def test_list_raid_cntrl_settings_by_instance_id(
+    def test_list_raid_controller_settings_by_instance_id(
             self, mock_requests,
             mock_wait_until_idrac_is_ready):
         expected_enum_attr = raid.RAIDEnumerableAttribute(
             name='RAIDCurrentControllerMode',
             instance_id='RAID.Integrated.1-1:RAIDCurrentControllerMode',  # noqa
             read_only=True,
-            current_value='RAID',
+            current_value=['RAID'],
             pending_value=None,
             fqdd='RAID.Integrated.1-1',
             possible_values=['RAID', 'Enhanced HBA'])
@@ -131,7 +131,7 @@ class ClientRAIDManagementTestCase(base.BaseTest):
             name='RAIDEffectiveSASAddress',
             instance_id='Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDEffectiveSASAddress',  # noqa
             read_only=True,
-            current_value='500056B3239C1AFD',
+            current_value=['500056B3239C1AFD'],
             pending_value=None,
             fqdd='Enclosure.Internal.0-1:RAID.Integrated.1-1',
             min_length=16,
@@ -141,7 +141,7 @@ class ClientRAIDManagementTestCase(base.BaseTest):
                 uris.DCIM_RAIDEnumeration]['ok']},
             {'text': test_utils.RAIDEnumerations[
                 uris.DCIM_RAIDString]['ok']}])
-        raid_settings = self.drac_client.list_raid_cntrl_settings(
+        raid_settings = self.drac_client.list_raid_controller_settings(
                 by_name=False)
         self.assertEqual(179, len(raid_settings))
         # enumerable attribute
@@ -160,14 +160,14 @@ class ClientRAIDManagementTestCase(base.BaseTest):
     @mock.patch.object(dracclient.client.WSManClient,
                        'wait_until_idrac_is_ready', spec_set=True,
                        autospec=True)
-    def test_list_raid_cntrl_settings_by_name(
+    def test_list_raid_controller_settings_by_name(
             self, mock_requests,
             mock_wait_until_idrac_is_ready):
         expected_enum_attr = raid.RAIDEnumerableAttribute(
             name='RAIDCurrentControllerMode',
             instance_id='RAID.Integrated.1-1:RAIDCurrentControllerMode',  # noqa
             read_only=True,
-            current_value='RAID',
+            current_value=['RAID'],
             pending_value=None,
             fqdd='RAID.Integrated.1-1',
             possible_values=['RAID', 'Enhanced HBA'])
@@ -175,7 +175,7 @@ class ClientRAIDManagementTestCase(base.BaseTest):
             name='RAIDEffectiveSASAddress',
             instance_id='Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDEffectiveSASAddress',  # noqa
             read_only=True,
-            current_value='500056B3239C1AFD',
+            current_value=['500056B3239C1AFD'],
             pending_value=None,
             fqdd='Enclosure.Internal.0-1:RAID.Integrated.1-1',
             min_length=16,
@@ -187,7 +187,7 @@ class ClientRAIDManagementTestCase(base.BaseTest):
             {'text': test_utils.RAIDEnumerations[
                 uris.DCIM_RAIDString]['ok']}])
 
-        raid_settings = self.drac_client.list_raid_cntrl_settings(
+        raid_settings = self.drac_client.list_raid_controller_settings(
                 by_name=True)
 
         self.assertEqual(27, len(raid_settings))
@@ -216,7 +216,6 @@ class ClientRAIDManagementTestCase(base.BaseTest):
                 uris.DCIM_RAIDEnumeration]['ok']},
             {'text': test_utils.RAIDEnumerations[
                 uris.DCIM_RAIDString]['ok']}])
-
         raid_cntrl_mode = self.drac_client.get_raid_controller_mode()
         self.assertEqual('RAID', raid_cntrl_mode)
 
@@ -226,9 +225,9 @@ class ClientRAIDManagementTestCase(base.BaseTest):
     @mock.patch.object(dracclient.client.WSManClient,
                        'invoke', spec_set=True,
                        autospec=True)
-    def test_set_raid_cntrl_settings(self, mock_requests,
-                                     mock_invoke,
-                                     mock_wait_until_idrac_is_ready):
+    def test_set_raid_controller_settings(self, mock_requests,
+                                          mock_invoke,
+                                          mock_wait_until_idrac_is_ready):
 
         mock_requests.post('https://1.2.3.4:443/wsman', [
             {'text': test_utils.RAIDEnumerations[
@@ -240,7 +239,7 @@ class ClientRAIDManagementTestCase(base.BaseTest):
             test_utils.RAIDInvocations[uris.DCIM_RAIDService][
                 'SetAttributes']['ok'])
 
-        result = self.drac_client.set_raid_cntrl_settings(
+        result = self.drac_client.set_raid_controller_settings(
             {'RAIDRequestedControllerMode': 'RAID'},
             self.raid_controller_fqdd)
 
@@ -252,7 +251,7 @@ class ClientRAIDManagementTestCase(base.BaseTest):
     @mock.patch.object(dracclient.client.WSManClient,
                        'wait_until_idrac_is_ready', spec_set=True,
                        autospec=True)
-    def test_set_raid_cntrl_settings_with_unknown_attr(
+    def test_set_raid_controller_settings_with_unknown_attr(
             self, mock_requests, mock_wait_until_idrac_is_ready):
         mock_requests.post('https://1.2.3.4:443/wsman', [
             {'text': test_utils.RAIDEnumerations[
@@ -263,13 +262,13 @@ class ClientRAIDManagementTestCase(base.BaseTest):
                 uris.DCIM_RAIDService]['SetAttributes']['error']}])
 
         self.assertRaises(exceptions.InvalidParameterValue,
-                          self.drac_client.set_raid_cntrl_settings,
+                          self.drac_client.set_raid_controller_settings,
                           {'foo': 'bar'}, self.raid_controller_fqdd)
 
     @mock.patch.object(dracclient.client.WSManClient,
                        'wait_until_idrac_is_ready', spec_set=True,
                        autospec=True)
-    def test_set_raid_cntrl_settings_with_unchanged_attr(
+    def test_set_raid_controller_settings_with_unchanged_attr(
             self, mock_requests, mock_wait_until_idrac_is_ready):
         mock_requests.post('https://1.2.3.4:443/wsman', [
             {'text': test_utils.RAIDEnumerations[
@@ -277,7 +276,7 @@ class ClientRAIDManagementTestCase(base.BaseTest):
             {'text': test_utils.RAIDEnumerations[
                 uris.DCIM_RAIDString]['ok']}])
 
-        result = self.drac_client.set_raid_cntrl_settings(
+        result = self.drac_client.set_raid_controller_settings(
             {'RAIDdefaultWritePolicy': 'WriteBack'},
             self.raid_controller_fqdd)
 
@@ -289,7 +288,7 @@ class ClientRAIDManagementTestCase(base.BaseTest):
     @mock.patch.object(dracclient.client.WSManClient,
                        'wait_until_idrac_is_ready', spec_set=True,
                        autospec=True)
-    def test_set_raid_cntrl_settings_with_readonly_attr(
+    def test_set_raid_controller_settings_with_readonly_attr(
             self, mock_requests, mock_wait_until_idrac_is_ready):
         expected_message = ("Cannot set read-only RAID attributes: "
                             "['RAIDCurrentControllerMode'].")
@@ -301,14 +300,14 @@ class ClientRAIDManagementTestCase(base.BaseTest):
 
         self.assertRaisesRegexp(
             exceptions.DRACOperationFailed, re.escape(expected_message),
-            self.drac_client.set_raid_cntrl_settings,
+            self.drac_client.set_raid_controller_settings,
             {'RAIDCurrentControllerMode': 'Enhanced HBA'},
             self.raid_controller_fqdd)
 
     @mock.patch.object(dracclient.client.WSManClient,
                        'wait_until_idrac_is_ready', spec_set=True,
                        autospec=True)
-    def test_set_raid_cntrl_settings_with_incorrect_enum_value(
+    def test_set_raid_controller_settings_with_incorrect_enum_value(
             self, mock_requests, mock_wait_until_idrac_is_ready):
         expected_message = ("Attribute 'RAIDRequestedControllerMode' cannot "
                             "be set to value 'foo'. It must be in "
@@ -321,7 +320,7 @@ class ClientRAIDManagementTestCase(base.BaseTest):
                 uris.DCIM_RAIDString]['ok']}])
         self.assertRaisesRegexp(
             exceptions.DRACOperationFailed, re.escape(expected_message),
-            self.drac_client.set_raid_cntrl_settings,
+            self.drac_client.set_raid_controller_settings,
             {'RAIDRequestedControllerMode': 'foo'}, self.raid_controller_fqdd)
 
     @mock.patch.object(dracclient.client.WSManClient,

--- a/dracclient/tests/utils.py
+++ b/dracclient/tests/utils.py
@@ -253,6 +253,9 @@ RAIDEnumerations = {
     },
     uris.DCIM_RAIDString: {
         'ok': load_wsman_xml('raid_string-enum-ok')
+    },
+    uris.DCIM_RAIDInteger: {
+        'ok': load_wsman_xml('raid_integer-enum-ok')
     }
 }
 

--- a/dracclient/tests/utils.py
+++ b/dracclient/tests/utils.py
@@ -247,6 +247,12 @@ RAIDEnumerations = {
     },
     uris.DCIM_VirtualDiskView: {
         'ok': load_wsman_xml('virtual_disk_view-enum-ok')
+    },
+    uris.DCIM_RAIDEnumeration: {
+        'ok': load_wsman_xml('raid_enumeration-enum-ok')
+    },
+    uris.DCIM_RAIDString: {
+        'ok': load_wsman_xml('raid_string-enum-ok')
     }
 }
 
@@ -283,6 +289,12 @@ RAIDInvocations = {
                 'raid_service-invoke-clear_foreign_config-no_foreign_drive'),
             'invalid_controller_id': load_wsman_xml(
                 'raid_service-invoke-clear_foreign_config-invalid_controller'),
+        },
+        'SetAttributes': {
+            'ok': load_wsman_xml(
+                'raid_service-invoke-set_attributes-ok'),
+            'error': load_wsman_xml(
+                'raid_service-invoke-set_attributes-error'),
         }
     }
 }

--- a/dracclient/tests/wsman_mocks/raid_enumeration-enum-ok.xml
+++ b/dracclient/tests/wsman_mocks/raid_enumeration-enum-ok.xml
@@ -1,0 +1,2347 @@
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+	xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+	xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+	xmlns:wsman="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+	xmlns:n1="http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_RAIDEnumeration"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <s:Header>
+		<wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+                <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</wsa:Action>
+                <wsa:RelatesTo>uuid:41a4f623-7f99-43b9-b240-4a773aa39860</wsa:RelatesTo>
+                <wsa:MessageID>uuid:3b204fe0-9caa-1caa-a2f1-614a498fd94c</wsa:MessageID>
+        </s:Header>
+        <s:Body>
+		<wsen:EnumerateResponse>
+	        	<wsman:Items>
+				<n1:DCIM_RAIDEnumeration>
+		  			<n1:AttributeName>RAIDSupportedRAIDLevels</n1:AttributeName>
+					<n1:CurrentValue>2(RAID-0)</n1:CurrentValue>
+					<n1:CurrentValue>4(RAID-1)</n1:CurrentValue>
+					<n1:CurrentValue>64(RAID-5)</n1:CurrentValue>
+					<n1:CurrentValue>128(RAID-6)</n1:CurrentValue>
+					<n1:CurrentValue>2048(RAID-10)</n1:CurrentValue>
+					<n1:CurrentValue>8192(RAID-50)</n1:CurrentValue>
+					<n1:CurrentValue>16384(RAID-60)</n1:CurrentValue>
+					<n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+					<n1:InstanceID>RAID.Integrated.1-1:RAIDSupportedRAIDLevels</n1:InstanceID>
+					<n1:IsReadOnly>true</n1:IsReadOnly>
+					<n1:PendingValue xsi:nil="true"/>
+					<n1:PossibleValues>2(RAID-0)</n1:PossibleValues>
+					<n1:PossibleValues>4(RAID-1)</n1:PossibleValues>
+					<n1:PossibleValues>64(RAID-5)</n1:PossibleValues>
+					<n1:PossibleValues>128(RAID-6)</n1:PossibleValues>
+					<n1:PossibleValues>2048(RAID-10)</n1:PossibleValues>
+					<n1:PossibleValues>8192(RAID-50)</n1:PossibleValues>
+					<n1:PossibleValues>16384(RAID-60)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+		  			<n1:AttributeName>RAIDSupportedDiskProt</n1:AttributeName>
+		  			<n1:CurrentValue>SAS</n1:CurrentValue>
+		  			<n1:CurrentValue>SATA</n1:CurrentValue>
+		  			<n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+		  			<n1:InstanceID>RAID.Integrated.1-1:RAIDSupportedDiskProt</n1:InstanceID>
+		  			<n1:IsReadOnly>true</n1:IsReadOnly>
+		  			<n1:PendingValue xsi:nil="true"/>
+		  			<n1:PossibleValues>SAS</n1:PossibleValues>
+		  			<n1:PossibleValues>SATA</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+		  			<n1:AttributeName>RAIDSupportedInitTypes</n1:AttributeName>
+		  			<n1:CurrentValue>Fast</n1:CurrentValue>
+		  			<n1:CurrentValue>Full</n1:CurrentValue>
+		  			<n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+		  			<n1:InstanceID>RAID.Integrated.1-1:RAIDSupportedInitTypes</n1:InstanceID>
+		  			<n1:IsReadOnly>true</n1:IsReadOnly>
+		  			<n1:PendingValue xsi:nil="true"/>
+		  			<n1:PossibleValues>Fast</n1:PossibleValues>
+		  			<n1:PossibleValues>Full</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDloadBalancedMode</n1:AttributeName>
+				  	<n1:CurrentValue>Automatic</n1:CurrentValue>
+				  	<n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>RAID.Integrated.1-1:RAIDloadBalancedMode</n1:InstanceID>
+				  	<n1:IsReadOnly>false</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>Automatic</n1:PossibleValues>
+				  	<n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDccMode</n1:AttributeName>
+				  	<n1:CurrentValue>Normal</n1:CurrentValue>
+					<n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>RAID.Integrated.1-1:RAIDccMode</n1:InstanceID>
+				  	<n1:IsReadOnly>false</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>Normal</n1:PossibleValues>
+				  	<n1:PossibleValues>Stop on Error</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDprMode</n1:AttributeName>
+				  	<n1:CurrentValue>Automatic</n1:CurrentValue>
+				  	<n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>RAID.Integrated.1-1:RAIDprMode</n1:InstanceID>
+				  	<n1:IsReadOnly>false</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>Disabled</n1:PossibleValues>
+				  	<n1:PossibleValues>Automatic</n1:PossibleValues>
+				  	<n1:PossibleValues>Manual</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDPatrolReadUnconfiguredArea</n1:AttributeName>
+				  	<n1:CurrentValue>Enabled</n1:CurrentValue>
+				  	<n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>RAID.Integrated.1-1:RAIDPatrolReadUnconfiguredArea</n1:InstanceID>
+				  	<n1:IsReadOnly>false</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>Disabled</n1:PossibleValues>
+				  	<n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDcopybackMode</n1:AttributeName>
+				  	<n1:CurrentValue>On</n1:CurrentValue>
+				  	<n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>RAID.Integrated.1-1:RAIDcopybackMode</n1:InstanceID>
+				  	<n1:IsReadOnly>false</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>On</n1:PossibleValues>
+				  	<n1:PossibleValues>On with SMART</n1:PossibleValues>
+				  	<n1:PossibleValues>Off</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDEnhancedAutoImportForeignConfig</n1:AttributeName>
+				  	<n1:CurrentValue>Disabled</n1:CurrentValue>
+				  	<n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>RAID.Integrated.1-1:RAIDEnhancedAutoImportForeignConfig</n1:InstanceID>
+				  	<n1:IsReadOnly>false</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>Disabled</n1:PossibleValues>
+				  	<n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDControllerBootMode</n1:AttributeName>
+				  	<n1:CurrentValue>Headless Mode Continue On Error</n1:CurrentValue>
+				  	<n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>RAID.Integrated.1-1:RAIDControllerBootMode</n1:InstanceID>
+				  	<n1:IsReadOnly>false</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>User Mode</n1:PossibleValues>
+				  	<n1:PossibleValues>Continue Boot On Error</n1:PossibleValues>
+				  	<n1:PossibleValues>Headless Mode Continue On Error</n1:PossibleValues>
+				  	<n1:PossibleValues>Headless Safe Mode</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDCurrentControllerMode</n1:AttributeName>
+				  	<n1:CurrentValue>RAID</n1:CurrentValue>
+				  	<n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>RAID.Integrated.1-1:RAIDCurrentControllerMode</n1:InstanceID>
+				  	<n1:IsReadOnly>true</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>RAID</n1:PossibleValues>
+				  	<n1:PossibleValues>Enhanced HBA</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDRequestedControllerMode</n1:AttributeName>
+				  	<n1:CurrentValue>None</n1:CurrentValue>
+				  	<n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>RAID.Integrated.1-1:RAIDRequestedControllerMode</n1:InstanceID>
+				  	<n1:IsReadOnly>false</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>RAID</n1:PossibleValues>
+				  	<n1:PossibleValues>Enhanced HBA</n1:PossibleValues>
+				  	<n1:PossibleValues>None</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDMode</n1:AttributeName>
+				  	<n1:CurrentValue>None</n1:CurrentValue>
+				  	<n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>RAID.Integrated.1-1:RAIDMode</n1:InstanceID>
+				  	<n1:IsReadOnly>true</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>None</n1:PossibleValues>
+				  	<n1:PossibleValues>Linux</n1:PossibleValues>
+				  	<n1:PossibleValues>Windows</n1:PossibleValues>
+				  	<n1:PossibleValues>Mixed</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDpersistentHotspare</n1:AttributeName>
+				  	<n1:CurrentValue>Disabled</n1:CurrentValue>
+				  	<n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>RAID.Integrated.1-1:RAIDpersistentHotspare</n1:InstanceID>
+				  	<n1:IsReadOnly>false</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>Disabled</n1:PossibleValues>
+				  	<n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDMaxCapableSpeed</n1:AttributeName>
+				  	<n1:CurrentValue>12_GBS</n1:CurrentValue>
+				  	<n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>RAID.Integrated.1-1:RAIDMaxCapableSpeed</n1:InstanceID>
+				  	<n1:IsReadOnly>true</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+				  	<n1:PossibleValues>3_GBS</n1:PossibleValues>
+				  	<n1:PossibleValues>6_GBS</n1:PossibleValues>
+				  	<n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDSupportedInitTypes</n1:AttributeName>
+				  	<n1:CurrentValue>None</n1:CurrentValue>
+				  	<n1:FQDD>AHCI.Embedded.1-1</n1:FQDD>
+				  	<n1:InstanceID>AHCI.Embedded.1-1:RAIDSupportedInitTypes</n1:InstanceID>
+				  	<n1:IsReadOnly>true</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>None</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDMode</n1:AttributeName>
+				  	<n1:CurrentValue>None</n1:CurrentValue>
+				  	<n1:FQDD>AHCI.Embedded.1-1</n1:FQDD>
+				  	<n1:InstanceID>AHCI.Embedded.1-1:RAIDMode</n1:InstanceID>
+				  	<n1:IsReadOnly>true</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>None</n1:PossibleValues>
+				  	<n1:PossibleValues>Linux</n1:PossibleValues>
+				  	<n1:PossibleValues>Windows</n1:PossibleValues>
+				  	<n1:PossibleValues>Mixed</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDSupportedInitTypes</n1:AttributeName>
+				  	<n1:CurrentValue>None</n1:CurrentValue>
+				  	<n1:FQDD>AHCI.Embedded.2-1</n1:FQDD>
+				  	<n1:InstanceID>AHCI.Embedded.2-1:RAIDSupportedInitTypes</n1:InstanceID>
+				  	<n1:IsReadOnly>true</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>None</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDMode</n1:AttributeName>
+				  	<n1:CurrentValue>None</n1:CurrentValue>
+				  	<n1:FQDD>AHCI.Embedded.2-1</n1:FQDD>
+				  	<n1:InstanceID>AHCI.Embedded.2-1:RAIDMode</n1:InstanceID>
+				  	<n1:IsReadOnly>true</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>None</n1:PossibleValues>
+				  	<n1:PossibleValues>Linux</n1:PossibleValues>
+				  	<n1:PossibleValues>Windows</n1:PossibleValues>
+				  	<n1:PossibleValues>Mixed</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+				  	<n1:CurrentValue>WriteBack</n1:CurrentValue>
+				  	<n1:FQDD>Disk.Virtual.0:RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>Disk.Virtual.0:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+				  	<n1:IsReadOnly>false</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>WriteThrough</n1:PossibleValues>
+				  	<n1:PossibleValues>WriteBack</n1:PossibleValues>
+				  	<n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+				  	<n1:CurrentValue>ReadAhead</n1:CurrentValue>
+				  	<n1:FQDD>Disk.Virtual.0:RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>Disk.Virtual.0:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+				  	<n1:IsReadOnly>false</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+				  	<n1:PossibleValues>ReadAhead</n1:PossibleValues>
+				  	<n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+				  	<n1:CurrentValue>Disabled</n1:CurrentValue>
+				  	<n1:FQDD>Disk.Virtual.0:RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>Disk.Virtual.0:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+				  	<n1:IsReadOnly>false</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>Default</n1:PossibleValues>
+				  	<n1:PossibleValues>Enabled</n1:PossibleValues>
+				  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>T10PIStatus</n1:AttributeName>
+				  	<n1:CurrentValue>Disabled</n1:CurrentValue>
+				  	<n1:FQDD>Disk.Virtual.0:RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>Disk.Virtual.0:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+				  	<n1:IsReadOnly>true</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>Disabled</n1:PossibleValues>
+				  	<n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+				  	<n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+				  	<n1:FQDD>Disk.Virtual.0:RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>Disk.Virtual.0:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+				  	<n1:IsReadOnly>true</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>0</n1:PossibleValues>
+				  	<n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+				  	<n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+				 	<n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+				  	<n1:CurrentValue>WriteBack</n1:CurrentValue>
+				  	<n1:FQDD>Disk.Virtual.1:RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>Disk.Virtual.1:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+				  	<n1:IsReadOnly>false</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>WriteThrough</n1:PossibleValues>
+				  	<n1:PossibleValues>WriteBack</n1:PossibleValues>
+				  	<n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+				  	<n1:CurrentValue>ReadAhead</n1:CurrentValue>
+				  	<n1:FQDD>Disk.Virtual.1:RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>Disk.Virtual.1:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+				  	<n1:IsReadOnly>false</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+				  	<n1:PossibleValues>ReadAhead</n1:PossibleValues>
+				  	<n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+				  	<n1:CurrentValue>Disabled</n1:CurrentValue>
+				 	<n1:FQDD>Disk.Virtual.1:RAID.Integrated.1-1</n1:FQDD>
+					<n1:InstanceID>Disk.Virtual.1:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+					<n1:IsReadOnly>false</n1:IsReadOnly>
+					<n1:PendingValue xsi:nil="true"/>
+					<n1:PossibleValues>Default</n1:PossibleValues>
+					<n1:PossibleValues>Enabled</n1:PossibleValues>
+					<n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					<n1:AttributeName>T10PIStatus</n1:AttributeName>
+					<n1:CurrentValue>Disabled</n1:CurrentValue>
+					<n1:FQDD>Disk.Virtual.1:RAID.Integrated.1-1</n1:FQDD>
+					<n1:InstanceID>Disk.Virtual.1:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+					<n1:IsReadOnly>true</n1:IsReadOnly>
+					<n1:PendingValue xsi:nil="true"/>
+					<n1:PossibleValues>Disabled</n1:PossibleValues>
+					<n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					<n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+				 	<n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+				  	<n1:FQDD>Disk.Virtual.1:RAID.Integrated.1-1</n1:FQDD>
+					<n1:InstanceID>Disk.Virtual.1:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+					<n1:IsReadOnly>true</n1:IsReadOnly>
+					<n1:PendingValue xsi:nil="true"/>
+					<n1:PossibleValues>0</n1:PossibleValues>
+					<n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+					<n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+					<n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+					<n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+					<n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+					<n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+					<n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+					<n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+					<n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+					<n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+					<n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+					<n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+					<n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+					<n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+					<n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+					<n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+				  	<n1:CurrentValue>WriteBack</n1:CurrentValue>
+				  	<n1:FQDD>Disk.Virtual.2:RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>Disk.Virtual.2:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+				  	<n1:IsReadOnly>false</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>WriteThrough</n1:PossibleValues>
+				  	<n1:PossibleValues>WriteBack</n1:PossibleValues>
+				  	<n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+				  	<n1:CurrentValue>ReadAhead</n1:CurrentValue>
+				  	<n1:FQDD>Disk.Virtual.2:RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>Disk.Virtual.2:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+				  	<n1:IsReadOnly>false</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+				  	<n1:PossibleValues>ReadAhead</n1:PossibleValues>
+				  	<n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+				  	<n1:CurrentValue>Disabled</n1:CurrentValue>
+				  	<n1:FQDD>Disk.Virtual.2:RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>Disk.Virtual.2:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+				  	<n1:IsReadOnly>false</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>Default</n1:PossibleValues>
+				  	<n1:PossibleValues>Enabled</n1:PossibleValues>
+				  	<n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>T10PIStatus</n1:AttributeName>
+				  	<n1:CurrentValue>Disabled</n1:CurrentValue>
+				  	<n1:FQDD>Disk.Virtual.2:RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>Disk.Virtual.2:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+				  	<n1:IsReadOnly>true</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>Disabled</n1:PossibleValues>
+				  	<n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	<n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+				  	<n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+				  	<n1:FQDD>Disk.Virtual.2:RAID.Integrated.1-1</n1:FQDD>
+				  	<n1:InstanceID>Disk.Virtual.2:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+				  	<n1:IsReadOnly>true</n1:IsReadOnly>
+				  	<n1:PendingValue xsi:nil="true"/>
+				  	<n1:PossibleValues>0</n1:PossibleValues>
+				  	<n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+				  	<n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+				  	<n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	  <n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+				  	  <n1:CurrentValue>WriteBack</n1:CurrentValue>
+				  	  <n1:FQDD>Disk.Virtual.3:RAID.Integrated.1-1</n1:FQDD>
+				  	  <n1:InstanceID>Disk.Virtual.3:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+				  	  <n1:IsReadOnly>false</n1:IsReadOnly>
+				  	  <n1:PendingValue xsi:nil="true"/>
+				  	  <n1:PossibleValues>WriteThrough</n1:PossibleValues>
+				  	  <n1:PossibleValues>WriteBack</n1:PossibleValues>
+				  	  <n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+					  <n1:CurrentValue>ReadAhead</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.3:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.3:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+				  	  <n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+				  	  <n1:PossibleValues>ReadAhead</n1:PossibleValues>
+				  	  <n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.3:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.3:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Default</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>T10PIStatus</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.3:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.3:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+					  <n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.3:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.3:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>0</n1:PossibleValues>
+					  <n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+					  <n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	  <n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+				  	  <n1:CurrentValue>WriteBack</n1:CurrentValue>
+				  	  <n1:FQDD>Disk.Virtual.4:RAID.Integrated.1-1</n1:FQDD>
+				  	  <n1:InstanceID>Disk.Virtual.4:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+				  	  <n1:IsReadOnly>false</n1:IsReadOnly>
+				  	  <n1:PendingValue xsi:nil="true"/>
+				  	  <n1:PossibleValues>WriteThrough</n1:PossibleValues>
+				  	  <n1:PossibleValues>WriteBack</n1:PossibleValues>
+				  	  <n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	  <n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+				  	  <n1:CurrentValue>ReadAhead</n1:CurrentValue>
+				  	  <n1:FQDD>Disk.Virtual.4:RAID.Integrated.1-1</n1:FQDD>
+				  	  <n1:InstanceID>Disk.Virtual.4:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+				  	  <n1:IsReadOnly>false</n1:IsReadOnly>
+				  	  <n1:PendingValue xsi:nil="true"/>
+				  	  <n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+				  	  <n1:PossibleValues>ReadAhead</n1:PossibleValues>
+				  	  <n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	  <n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+				  	  <n1:CurrentValue>Disabled</n1:CurrentValue>
+				  	  <n1:FQDD>Disk.Virtual.4:RAID.Integrated.1-1</n1:FQDD>
+				  	  <n1:InstanceID>Disk.Virtual.4:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+				  	  <n1:IsReadOnly>false</n1:IsReadOnly>
+				  	  <n1:PendingValue xsi:nil="true"/>
+				  	  <n1:PossibleValues>Default</n1:PossibleValues>
+				  	  <n1:PossibleValues>Enabled</n1:PossibleValues>
+				  	  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	  <n1:AttributeName>T10PIStatus</n1:AttributeName>
+				  	  <n1:CurrentValue>Disabled</n1:CurrentValue>
+				  	  <n1:FQDD>Disk.Virtual.4:RAID.Integrated.1-1</n1:FQDD>
+				  	  <n1:InstanceID>Disk.Virtual.4:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+				  	  <n1:IsReadOnly>true</n1:IsReadOnly>
+				  	  <n1:PendingValue xsi:nil="true"/>
+				  	  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				  	  <n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+				  	  <n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+				  	  <n1:FQDD>Disk.Virtual.4:RAID.Integrated.1-1</n1:FQDD>
+				  	  <n1:InstanceID>Disk.Virtual.4:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+				  	  <n1:IsReadOnly>true</n1:IsReadOnly>
+				  	  <n1:PendingValue xsi:nil="true"/>
+				  	  <n1:PossibleValues>0</n1:PossibleValues>
+				  	  <n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+				  	  <n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+				 	  <n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+				  	  <n1:CurrentValue>WriteBack</n1:CurrentValue>
+				  	  <n1:FQDD>Disk.Virtual.5:RAID.Integrated.1-1</n1:FQDD>
+				  	  <n1:InstanceID>Disk.Virtual.5:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+				  	  <n1:IsReadOnly>false</n1:IsReadOnly>
+				  	  <n1:PendingValue xsi:nil="true"/>
+				  	  <n1:PossibleValues>WriteThrough</n1:PossibleValues>
+				  	  <n1:PossibleValues>WriteBack</n1:PossibleValues>
+				  	  <n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	  <n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+				  	  <n1:CurrentValue>ReadAhead</n1:CurrentValue>
+				  	  <n1:FQDD>Disk.Virtual.5:RAID.Integrated.1-1</n1:FQDD>
+				  	  <n1:InstanceID>Disk.Virtual.5:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+				  	  <n1:IsReadOnly>false</n1:IsReadOnly>
+				  	  <n1:PendingValue xsi:nil="true"/>
+				  	  <n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+				  	  <n1:PossibleValues>ReadAhead</n1:PossibleValues>
+				  	  <n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	  <n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+				  	  <n1:CurrentValue>Disabled</n1:CurrentValue>
+				  	  <n1:FQDD>Disk.Virtual.5:RAID.Integrated.1-1</n1:FQDD>
+				  	  <n1:InstanceID>Disk.Virtual.5:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+				  	  <n1:IsReadOnly>false</n1:IsReadOnly>
+				  	  <n1:PendingValue xsi:nil="true"/>
+				  	  <n1:PossibleValues>Default</n1:PossibleValues>
+				  	  <n1:PossibleValues>Enabled</n1:PossibleValues>
+				  	  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	  <n1:AttributeName>T10PIStatus</n1:AttributeName>
+				  	  <n1:CurrentValue>Disabled</n1:CurrentValue>
+				  	  <n1:FQDD>Disk.Virtual.5:RAID.Integrated.1-1</n1:FQDD>
+				  	  <n1:InstanceID>Disk.Virtual.5:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+				  	  <n1:IsReadOnly>true</n1:IsReadOnly>
+				  	  <n1:PendingValue xsi:nil="true"/>
+				  	  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				  	  <n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+				  	  <n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+				  	  <n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+				  	  <n1:FQDD>Disk.Virtual.5:RAID.Integrated.1-1</n1:FQDD>
+				  	  <n1:InstanceID>Disk.Virtual.5:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+				  	  <n1:IsReadOnly>true</n1:IsReadOnly>
+				  	  <n1:PendingValue xsi:nil="true"/>
+				  	  <n1:PossibleValues>0</n1:PossibleValues>
+				  	  <n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+				  	  <n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+				  	  <n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+					  <n1:CurrentValue>WriteBack</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.6:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.6:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>WriteThrough</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBack</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+					  <n1:CurrentValue>ReadAhead</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.6:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.6:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>ReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.6:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.6:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Default</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>T10PIStatus</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.6:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.6:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+					  <n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.6:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.6:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>0</n1:PossibleValues>
+					  <n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+					  <n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+					  <n1:CurrentValue>WriteBack</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.7:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.7:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>WriteThrough</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBack</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+					  <n1:CurrentValue>ReadAhead</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.7:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.7:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>ReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.7:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.7:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Default</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>T10PIStatus</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.7:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.7:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+					  <n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.7:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.7:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>0</n1:PossibleValues>
+					  <n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+					  <n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+					  <n1:CurrentValue>WriteBack</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.8:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.8:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>WriteThrough</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBack</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+					  <n1:CurrentValue>ReadAhead</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.8:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.8:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>ReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.8:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.8:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Default</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>T10PIStatus</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.8:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.8:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+					  <n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.8:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.8:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>0</n1:PossibleValues>
+					  <n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+					  <n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+					  <n1:CurrentValue>WriteBack</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.9:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.9:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>WriteThrough</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBack</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+					  <n1:CurrentValue>ReadAhead</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.9:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.9:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>ReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.9:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.9:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Default</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>T10PIStatus</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.9:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.9:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+					  <n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.9:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.9:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>0</n1:PossibleValues>
+					  <n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+					  <n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+					  <n1:CurrentValue>WriteBack</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.10:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.10:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>WriteThrough</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBack</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+					  <n1:CurrentValue>ReadAhead</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.10:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.10:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>ReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.10:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.10:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Default</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>T10PIStatus</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.10:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.10:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+					  <n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.10:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.10:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>0</n1:PossibleValues>
+					  <n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+					  <n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+					  <n1:CurrentValue>WriteBack</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.11:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.11:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>WriteThrough</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBack</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+					  <n1:CurrentValue>ReadAhead</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.11:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.11:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>ReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.11:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.11:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Default</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>T10PIStatus</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.11:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.11:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+					  <n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.11:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.11:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>0</n1:PossibleValues>
+					  <n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+					  <n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+					  <n1:CurrentValue>WriteBack</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.12:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.12:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>WriteThrough</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBack</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+					  <n1:CurrentValue>ReadAhead</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.12:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.12:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>ReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.12:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.12:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Default</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>T10PIStatus</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.12:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.12:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+					  <n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.12:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.12:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>0</n1:PossibleValues>
+					  <n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+					  <n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+					  <n1:CurrentValue>WriteBack</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.13:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.13:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>WriteThrough</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBack</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+					  <n1:CurrentValue>ReadAhead</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.13:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.13:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>ReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+					  <n1:CurrentValue>Enabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.13:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.13:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Default</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>T10PIStatus</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.13:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.13:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+					  <n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.13:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.13:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>0</n1:PossibleValues>
+					  <n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+					  <n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+					  <n1:CurrentValue>WriteBack</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.14:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.14:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>WriteThrough</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBack</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+					  <n1:CurrentValue>ReadAhead</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.14:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.14:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>ReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+					  <n1:CurrentValue>Enabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.14:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.14:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Default</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>T10PIStatus</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.14:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.14:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+					  <n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.14:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.14:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>0</n1:PossibleValues>
+					  <n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+					  <n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+					  <n1:CurrentValue>WriteBack</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.15:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.15:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>WriteThrough</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBack</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+					  <n1:CurrentValue>ReadAhead</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.15:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.15:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>ReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+					  <n1:CurrentValue>Enabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.15:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.15:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Default</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>T10PIStatus</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.15:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.15:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+					  <n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.15:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.15:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>0</n1:PossibleValues>
+					  <n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+					  <n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+					  <n1:CurrentValue>WriteBack</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.16:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.16:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>WriteThrough</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBack</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+					  <n1:CurrentValue>ReadAhead</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.16:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.16:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>ReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+					  <n1:CurrentValue>Enabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.16:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.16:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Default</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>T10PIStatus</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.16:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.16:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+					  <n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.16:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.16:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>0</n1:PossibleValues>
+					  <n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+					  <n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+					  <n1:CurrentValue>WriteBack</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.17:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.17:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>WriteThrough</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBack</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+					  <n1:CurrentValue>ReadAhead</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.17:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.17:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>ReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.17:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.17:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Default</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>T10PIStatus</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.17:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.17:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+					  <n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.17:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.17:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>0</n1:PossibleValues>
+					  <n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+					  <n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultWritePolicy</n1:AttributeName>
+					  <n1:CurrentValue>WriteBack</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.18:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.18:RAID.Integrated.1-1:RAIDdefaultWritePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>WriteThrough</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBack</n1:PossibleValues>
+					  <n1:PossibleValues>WriteBackForce</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDdefaultReadPolicy</n1:AttributeName>
+					  <n1:CurrentValue>ReadAhead</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.18:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.18:RAID.Integrated.1-1:RAIDdefaultReadPolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>NoReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>ReadAhead</n1:PossibleValues>
+					  <n1:PossibleValues>AdaptiveReadAhead</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>DiskCachePolicy</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.18:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.18:RAID.Integrated.1-1:DiskCachePolicy</n1:InstanceID>
+					  <n1:IsReadOnly>false</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Default</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>T10PIStatus</n1:AttributeName>
+					  <n1:CurrentValue>Disabled</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.18:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.18:RAID.Integrated.1-1:T10PIStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Disabled</n1:PossibleValues>
+					  <n1:PossibleValues>Enabled</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDStripeSize</n1:AttributeName>
+					  <n1:CurrentValue>512(256 KB)</n1:CurrentValue>
+					  <n1:FQDD>Disk.Virtual.18:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Virtual.18:RAID.Integrated.1-1:RAIDStripeSize</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>0</n1:PossibleValues>
+					  <n1:PossibleValues>1(512 Bytes)</n1:PossibleValues>
+					  <n1:PossibleValues>2(1 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4(2 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8(4 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16(8 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32(16 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>64(32 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>128(64 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>256(128 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>512(256 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>1024(512 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>2048(1024 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>4096(2048 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>8192(4096 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>16384(8192 KB)</n1:PossibleValues>
+					  <n1:PossibleValues>32768(16384 KB)</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDMultipath</n1:AttributeName>
+					  <n1:CurrentValue>Off</n1:CurrentValue>
+					  <n1:FQDD>Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDMultipath</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Off</n1:PossibleValues>
+					  <n1:PossibleValues>On</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>BackplaneType</n1:AttributeName>
+					  <n1:CurrentValue>Not Shared</n1:CurrentValue>
+					  <n1:FQDD>Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Enclosure.Internal.0-1:RAID.Integrated.1-1:BackplaneType</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Not Shared</n1:PossibleValues>
+					  <n1:PossibleValues>Shared</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.0:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.0:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.0:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.0:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>12_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.0:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.0:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.1:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.1:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.1:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.1:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>12_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.1:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.1:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.2:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.2:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.2:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.2:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>12_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.2:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.2:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.3:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.3:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.3:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.3:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>12_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.3:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.3:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.4:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.4:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.4:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.4:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus
+				          </n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>12_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.4:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.4:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.5:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.5:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.5:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.5:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>12_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.5:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.5:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.6:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.6:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.6:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.6:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>12_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.6:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.6:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.7:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.7:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.7:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.7:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>12_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.7:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.7:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.8:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.8:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.8:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.8:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>12_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.8:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.8:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.9:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.9:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.9:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.9:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>12_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.9:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.9:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.10:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.10:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.10:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.10:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>12_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.10:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.10:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.11:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.11:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.11:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.11:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>12_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.11:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.11:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.12:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.12:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.12:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.12:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>6_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.12:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.12:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.13:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.13:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.13:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.13:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>6_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.13:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.13:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.14:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.14:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.14:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.14:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>6_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.14:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.14:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.15:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.15:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.15:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.15:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>6_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.15:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.15:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.16:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.16:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.16:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.16:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>12_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.16:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.16:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.17:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.17:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.17:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.17:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>12_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.17:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.17:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.18:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.18:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.18:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.18:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>12_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.18:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.18:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDPDState</n1:AttributeName>
+					  <n1:CurrentValue>Online</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.19:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.19:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDPDState</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>Unknown</n1:PossibleValues>
+					  <n1:PossibleValues>Ready</n1:PossibleValues>
+					  <n1:PossibleValues>Online</n1:PossibleValues>
+					  <n1:PossibleValues>Foreign</n1:PossibleValues>
+					  <n1:PossibleValues>Blocked</n1:PossibleValues>
+					  <n1:PossibleValues>Failed</n1:PossibleValues>
+					  <n1:PossibleValues>Non-RAID</n1:PossibleValues>
+					  <n1:PossibleValues>Missing</n1:PossibleValues>
+					  <n1:PossibleValues>Offline</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDHotSpareStatus</n1:AttributeName>
+					  <n1:CurrentValue>No</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.19:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.19:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDHotSpareStatus</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>No</n1:PossibleValues>
+					  <n1:PossibleValues>Dedicated</n1:PossibleValues>
+					  <n1:PossibleValues>Global</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+				<n1:DCIM_RAIDEnumeration>
+					  <n1:AttributeName>RAIDNegotiatedSpeed</n1:AttributeName>
+					  <n1:CurrentValue>12_GBS</n1:CurrentValue>
+					  <n1:FQDD>Disk.Bay.19:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+					  <n1:InstanceID>Disk.Bay.19:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNegotiatedSpeed</n1:InstanceID>
+					  <n1:IsReadOnly>true</n1:IsReadOnly>
+					  <n1:PendingValue xsi:nil="true"/>
+					  <n1:PossibleValues>1_5_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>3_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>6_GBS</n1:PossibleValues>
+					  <n1:PossibleValues>12_GBS</n1:PossibleValues>
+				</n1:DCIM_RAIDEnumeration>
+	      		</wsman:Items>
+		</wsen:EnumerateResponse>
+	</s:Body>
+</s:Envelope>
+

--- a/dracclient/tests/wsman_mocks/raid_integer-enum-ok.xml
+++ b/dracclient/tests/wsman_mocks/raid_integer-enum-ok.xml
@@ -1,0 +1,416 @@
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:wsman="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:n1="http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_RAIDInteger" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <s:Header>
+    <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+    <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</wsa:Action>
+    <wsa:RelatesTo>uuid:40206465-1566-46e3-bf05-9952ba57ec3c</wsa:RelatesTo>
+    <wsa:MessageID>uuid:6af777f7-9ef1-1ef1-b067-84d3878fd94c</wsa:MessageID>
+  </s:Header>
+  <s:Body>
+    <wsen:EnumerateResponse>
+      <wsman:Items>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDmaxSupportedVD</n1:AttributeName>
+          <n1:CurrentValue>240</n1:CurrentValue>
+          <n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>RAID.Integrated.1-1:RAIDmaxSupportedVD</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>0</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDmaxPDsInSpan</n1:AttributeName>
+          <n1:CurrentValue>32</n1:CurrentValue>
+          <n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>RAID.Integrated.1-1:RAIDmaxPDsInSpan</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>0</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDmaxSpansInVD</n1:AttributeName>
+          <n1:CurrentValue>8</n1:CurrentValue>
+          <n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>RAID.Integrated.1-1:RAIDmaxSpansInVD</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>0</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDrebuildRate</n1:AttributeName>
+          <n1:CurrentValue>30</n1:CurrentValue>
+          <n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>RAID.Integrated.1-1:RAIDrebuildRate</n1:InstanceID>
+          <n1:IsReadOnly>false</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>100</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDccRate</n1:AttributeName>
+          <n1:CurrentValue>30</n1:CurrentValue>
+          <n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>RAID.Integrated.1-1:RAIDccRate</n1:InstanceID>
+          <n1:IsReadOnly>false</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>100</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDreconstructRate</n1:AttributeName>
+          <n1:CurrentValue>30</n1:CurrentValue>
+          <n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>RAID.Integrated.1-1:RAIDreconstructRate</n1:InstanceID>
+          <n1:IsReadOnly>false</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>100</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDbgiRate</n1:AttributeName>
+          <n1:CurrentValue>30</n1:CurrentValue>
+          <n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>RAID.Integrated.1-1:RAIDbgiRate</n1:InstanceID>
+          <n1:IsReadOnly>false</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>100</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDprRate</n1:AttributeName>
+          <n1:CurrentValue>30</n1:CurrentValue>
+          <n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>RAID.Integrated.1-1:RAIDprRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>100</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDspinDownIdleTime</n1:AttributeName>
+          <n1:CurrentValue>30</n1:CurrentValue>
+          <n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>RAID.Integrated.1-1:RAIDspinDownIdleTime</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>65535</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDprIterations</n1:AttributeName>
+          <n1:CurrentValue>0</n1:CurrentValue>
+          <n1:FQDD>RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>RAID.Integrated.1-1:RAIDprIterations</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>1</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>4294967295</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDmaxSupportedVD</n1:AttributeName>
+          <n1:CurrentValue>0</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.2-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.2-1:RAIDmaxSupportedVD</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>0</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDmaxPDsInSpan</n1:AttributeName>
+          <n1:CurrentValue>0</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.2-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.2-1:RAIDmaxPDsInSpan</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>0</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDmaxSpansInVD</n1:AttributeName>
+          <n1:CurrentValue>0</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.2-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.2-1:RAIDmaxSpansInVD</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>0</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDrebuildRate</n1:AttributeName>
+          <n1:CurrentValue>255</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.2-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.2-1:RAIDrebuildRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>100</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDccRate</n1:AttributeName>
+          <n1:CurrentValue>255</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.2-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.2-1:RAIDccRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>100</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDreconstructRate</n1:AttributeName>
+          <n1:CurrentValue>255</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.2-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.2-1:RAIDreconstructRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>100</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDbgiRate</n1:AttributeName>
+          <n1:CurrentValue>255</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.2-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.2-1:RAIDbgiRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>100</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDprRate</n1:AttributeName>
+          <n1:CurrentValue>255</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.2-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.2-1:RAIDprRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>100</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDspinDownIdleTime</n1:AttributeName>
+          <n1:CurrentValue>0</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.2-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.2-1:RAIDspinDownIdleTime</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>65535</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDprIterations</n1:AttributeName>
+          <n1:CurrentValue>0</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.2-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.2-1:RAIDprIterations</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>1</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>4294967295</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDmaxSupportedVD</n1:AttributeName>
+          <n1:CurrentValue>0</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.1-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.1-1:RAIDmaxSupportedVD</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>0</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDmaxPDsInSpan</n1:AttributeName>
+          <n1:CurrentValue>0</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.1-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.1-1:RAIDmaxPDsInSpan</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>0</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDmaxSpansInVD</n1:AttributeName>
+          <n1:CurrentValue>0</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.1-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.1-1:RAIDmaxSpansInVD</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>0</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDrebuildRate</n1:AttributeName>
+          <n1:CurrentValue>255</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.1-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.1-1:RAIDrebuildRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>100</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDccRate</n1:AttributeName>
+          <n1:CurrentValue>255</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.1-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.1-1:RAIDccRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>100</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDreconstructRate</n1:AttributeName>
+          <n1:CurrentValue>255</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.1-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.1-1:RAIDreconstructRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>100</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDbgiRate</n1:AttributeName>
+          <n1:CurrentValue>255</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.1-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.1-1:RAIDbgiRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>100</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDprRate</n1:AttributeName>
+          <n1:CurrentValue>255</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.1-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.1-1:RAIDprRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>100</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDspinDownIdleTime</n1:AttributeName>
+          <n1:CurrentValue>0</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.1-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.1-1:RAIDspinDownIdleTime</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>0</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>65535</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDprIterations</n1:AttributeName>
+          <n1:CurrentValue>0</n1:CurrentValue>
+          <n1:FQDD>AHCI.Embedded.1-1</n1:FQDD>
+          <n1:InstanceID>AHCI.Embedded.1-1:RAIDprIterations</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>1</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>4294967295</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDNominalMediumRotationRate</n1:AttributeName>
+          <n1:CurrentValue>10000</n1:CurrentValue>
+          <n1:FQDD>Disk.Bay.0:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>Disk.Bay.0:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNominalMediumRotationRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>2</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>4294967295</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDNominalMediumRotationRate</n1:AttributeName>
+          <n1:CurrentValue>10000</n1:CurrentValue>
+          <n1:FQDD>Disk.Bay.1:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>Disk.Bay.1:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNominalMediumRotationRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>2</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>4294967295</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDNominalMediumRotationRate</n1:AttributeName>
+          <n1:CurrentValue>10000</n1:CurrentValue>
+          <n1:FQDD>Disk.Bay.2:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>Disk.Bay.2:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNominalMediumRotationRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>2</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>4294967295</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDNominalMediumRotationRate</n1:AttributeName>
+          <n1:CurrentValue>10000</n1:CurrentValue>
+          <n1:FQDD>Disk.Bay.3:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>Disk.Bay.3:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNominalMediumRotationRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>2</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>4294967295</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDNominalMediumRotationRate</n1:AttributeName>
+          <n1:CurrentValue>10000</n1:CurrentValue>
+          <n1:FQDD>Disk.Bay.4:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>Disk.Bay.4:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNominalMediumRotationRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>2</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>4294967295</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDNominalMediumRotationRate</n1:AttributeName>
+          <n1:CurrentValue>10000</n1:CurrentValue>
+          <n1:FQDD>Disk.Bay.5:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>Disk.Bay.5:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNominalMediumRotationRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>2</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>4294967295</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDNominalMediumRotationRate</n1:AttributeName>
+          <n1:CurrentValue>10000</n1:CurrentValue>
+          <n1:FQDD>Disk.Bay.6:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>Disk.Bay.6:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNominalMediumRotationRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>2</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>4294967295</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDNominalMediumRotationRate</n1:AttributeName>
+          <n1:CurrentValue>10000</n1:CurrentValue>
+          <n1:FQDD>Disk.Bay.7:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>Disk.Bay.7:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNominalMediumRotationRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>2</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>4294967295</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDNominalMediumRotationRate</n1:AttributeName>
+          <n1:CurrentValue>10000</n1:CurrentValue>
+          <n1:FQDD>Disk.Bay.8:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>Disk.Bay.8:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNominalMediumRotationRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>2</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>4294967295</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+        <n1:DCIM_RAIDInteger>
+          <n1:AttributeName>RAIDNominalMediumRotationRate</n1:AttributeName>
+          <n1:CurrentValue>10000</n1:CurrentValue>
+          <n1:FQDD>Disk.Bay.9:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>Disk.Bay.9:Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDNominalMediumRotationRate</n1:InstanceID>
+          <n1:IsReadOnly>true</n1:IsReadOnly>
+          <n1:LowerBound>2</n1:LowerBound>
+          <n1:PendingValue xsi:nil="true"/>
+          <n1:UpperBound>4294967295</n1:UpperBound>
+        </n1:DCIM_RAIDInteger>
+      </wsman:Items>
+      <wsman:EndOfSequence/>
+    </wsen:EnumerateResponse>
+  </s:Body>
+</s:Envelope>
+

--- a/dracclient/tests/wsman_mocks/raid_service-invoke-set_attributes-error.xml
+++ b/dracclient/tests/wsman_mocks/raid_service-invoke-set_attributes-error.xml
@@ -1,0 +1,21 @@
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+        xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+        xmlns:n1="http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_RAIDService">
+        <s:Header>
+                <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous
+                </wsa:To>
+                <wsa:Action>http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_RAIDService/SetAttributesResponse
+                </wsa:Action>
+                <wsa:RelatesTo>uuid:bf8adefe-6fc0-456d-b97c-fd8d4aca2d6c
+                </wsa:RelatesTo>
+                <wsa:MessageID>uuid:84abf7b9-7176-1176-a11c-a53ffbd9bed4
+                </wsa:MessageID>
+        </s:Header>
+        <s:Body>
+                <n1:SetAttributes_OUTPUT>
+                        <n1:Message>Invalid parameter value</n1:Message>
+                        <n1:MessageID>STOR004</n1:MessageID>
+                        <n1:ReturnValue>2</n1:ReturnValue>
+                </n1:SetAttributes_OUTPUT>
+        </s:Body>
+</s:Envelope>

--- a/dracclient/tests/wsman_mocks/raid_service-invoke-set_attributes-ok.xml
+++ b/dracclient/tests/wsman_mocks/raid_service-invoke-set_attributes-ok.xml
@@ -1,0 +1,24 @@
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+        xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+        xmlns:n1="http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_RAIDService">
+        <s:Header>
+                <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous
+                </wsa:To>
+                <wsa:Action>http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_RAIDService/SetAttributesResponse
+                </wsa:Action>
+                <wsa:RelatesTo>uuid:bf8adefe-6fc0-456d-b97c-fd8d4aca2d6c
+                </wsa:RelatesTo>
+                <wsa:MessageID>uuid:84abf7b9-7176-1176-a11c-a53ffbd9bed4
+                </wsa:MessageID>
+        </s:Header>
+        <s:Body>
+                <n1:SetAttributes_OUTPUT>
+			<n1:MessageID>STOR001</n1:MessageID>
+                        <n1:Message>The command was successful for all attributes</n1:Message>
+                        <n1:ReturnValue>0</n1:ReturnValue>
+                        <n1:RebootRequired>Yes</n1:RebootRequired>
+                        <n1:SetResult>Set PendingValue</n1:SetResult>
+                </n1:SetAttributes_OUTPUT>
+        </s:Body>
+</s:Envelope>
+

--- a/dracclient/tests/wsman_mocks/raid_string-enum-ok.xml
+++ b/dracclient/tests/wsman_mocks/raid_string-enum-ok.xml
@@ -1,0 +1,49 @@
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+	xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+	xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+	xmlns:wsman="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+	xmlns:n1="http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_RAIDString"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<s:Header>
+		<wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+		<wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</wsa:Action>
+		<wsa:RelatesTo>uuid:6f1e7eae-511a-4268-9913-c1ce1bb414be</wsa:RelatesTo>
+		<wsa:MessageID>uuid:6da65cf0-9cbb-1cbb-9773-deda878fd94c</wsa:MessageID>
+	</s:Header>
+	<s:Body>
+		<wsen:EnumerateResponse>
+			<wsman:Items>
+				<n1:DCIM_RAIDString>
+				  <n1:AttributeName>Name</n1:AttributeName>
+				  <n1:CurrentValue>Virtual Disk 0</n1:CurrentValue>
+				  <n1:FQDD>Disk.Virtual.0:RAID.Integrated.1-1</n1:FQDD>
+				  <n1:InstanceID>Disk.Virtual.0:RAID.Integrated.1-1:Name</n1:InstanceID>
+				  <n1:IsReadOnly>true</n1:IsReadOnly>
+				  <n1:MaxLength>129</n1:MaxLength>
+				  <n1:MinLength>0</n1:MinLength>
+				  <n1:PendingValue xsi:nil="true"/>
+				</n1:DCIM_RAIDString>
+				<n1:DCIM_RAIDString>
+				  <n1:AttributeName>Name</n1:AttributeName>
+				  <n1:CurrentValue>Virtual Disk 1</n1:CurrentValue>
+				  <n1:FQDD>Disk.Virtual.1:RAID.Integrated.1-1</n1:FQDD>
+				  <n1:InstanceID>Disk.Virtual.1:RAID.Integrated.1-1:Name</n1:InstanceID>
+				  <n1:IsReadOnly>true</n1:IsReadOnly>
+				  <n1:MaxLength>129</n1:MaxLength>
+				  <n1:MinLength>0</n1:MinLength>
+				  <n1:PendingValue xsi:nil="true"/>
+				</n1:DCIM_RAIDString>
+				<n1:DCIM_RAIDString>
+				  <n1:AttributeName>RAIDEffectiveSASAddress</n1:AttributeName>
+				  <n1:CurrentValue>500056B3239C1AFD</n1:CurrentValue>
+				  <n1:FQDD>Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:FQDD>
+				  <n1:InstanceID>Enclosure.Internal.0-1:RAID.Integrated.1-1:RAIDEffectiveSASAddress</n1:InstanceID>
+				  <n1:IsReadOnly>true</n1:IsReadOnly>
+				  <n1:MaxLength>16</n1:MaxLength>
+				  <n1:MinLength>16</n1:MinLength>
+				  <n1:PendingValue xsi:nil="true"/>
+				</n1:DCIM_RAIDString>
+			</wsman:Items>
+		</wsen:EnumerateResponse>
+	</s:Body>
+</s:Envelope>

--- a/dracclient/utils.py
+++ b/dracclient/utils.py
@@ -411,7 +411,7 @@ def set_settings(settings_type,
         properties['AttributeName'] = [current_settings[attr].name for
                                        attr in attrib_names]
     else:
-        properties['AttributeName'] =  attrib_names
+        properties['AttributeName'] = attrib_names
     doc = client.invoke(resource_uri, 'SetAttributes',
                         selectors, properties,
                         wait_for_idrac=wait_for_idrac)

--- a/dracclient/utils.py
+++ b/dracclient/utils.py
@@ -360,8 +360,11 @@ def set_settings(settings_type,
     candidates = set(new_settings)
 
     for attr in candidates:
-        if str(new_settings[attr]) == str(
-                current_settings[attr].current_value):
+        if settings_type == 'RAID':
+            current_setting_value = current_settings[attr].current_value[0]
+        else:
+            current_setting_value = current_settings[attr].current_value
+        if str(new_settings[attr]) == str(current_setting_value):
             unchanged_attribs.append(attr)
         elif current_settings[attr].read_only:
             read_only_keys.append(attr)

--- a/dracclient/utils.py
+++ b/dracclient/utils.py
@@ -132,9 +132,7 @@ def get_all_wsman_resource_attrs(doc, resource_uri, attr_name, nullable=False):
 
 def build_return_dict(doc, resource_uri,
                       is_commit_required_value=None,
-                      is_reboot_required_value=None,
-                      commit_required_value=None,
-                      include_commit_required=False):
+                      is_reboot_required_value=None):
     """Builds a dictionary to be returned
 
        Build a dictionary to be returned from WSMAN operations that are not
@@ -148,17 +146,9 @@ def build_return_dict(doc, resource_uri,
     :param is_reboot_required_value: The value to be returned for
            is_reboot_required, or None if the value should be determined
            from the doc.
-    :param commit_required_value: The value to be returned for
-           commit_required, or None if the value should be determined
-           from the doc.
-    :parm include_commit_required: Indicates if the deprecated commit_required
-                                   should be returned in the result.
     :returns: a dictionary containing:
              - is_commit_required: indicates if a commit is required.
              - is_reboot_required: indicates if a reboot is required.
-             - commit_required: a deprecated key indicating if a commit is
-               required.  This key actually has a value that indicates if a
-               reboot is required.
     """
 
     if is_reboot_required_value is not None and \
@@ -179,14 +169,6 @@ def build_return_dict(doc, resource_uri,
         is_reboot_required_value = reboot_required(doc, resource_uri)
 
     result['is_reboot_required'] = is_reboot_required_value
-
-    # Include commit_required in the response for backwards compatibility
-    # TBD: Remove this parameter in the future
-    if include_commit_required:
-        if commit_required_value is None:
-            commit_required_value = is_reboot_required(doc, resource_uri)
-
-        result['commit_required'] = commit_required_value
 
     return result
 
@@ -319,7 +301,6 @@ def set_settings(settings_type,
                  cim_name,
                  target,
                  name_formatter=None,
-                 include_commit_required=False,
                  wait_for_idrac=True,
                  by_name=True):
     """Generically handles setting various types of settings on the iDRAC
@@ -342,17 +323,10 @@ def set_settings(settings_type,
     :param name_formatter: a method used to format the keys in the
                            returned dictionary.  By default,
                            attribute.name will be used.
-    :parm include_commit_required: Indicates if the deprecated commit_required
-                                   should be returned in the result.
     :param wait_for_idrac: indicates whether or not to wait for the
                            iDRAC to be ready to accept commands before issuing
                            the command
     :returns: a dictionary containing:
-             - The commit_required key with a boolean value indicating
-               whether a config job must be created for the values to be
-               applied.  This key actually has a value that indicates if
-               a reboot is required.  This key has been deprecated and
-               will be removed in a future release.
              - The is_commit_required key with a boolean value indicating
                whether a config job must be created for the values to be
                applied.
@@ -423,10 +397,8 @@ def set_settings(settings_type,
         return build_return_dict(
             None,
             resource_uri,
-            include_commit_required=include_commit_required,
             is_commit_required_value=False,
-            is_reboot_required_value=constants.RebootRequired.false,
-            commit_required_value=False)
+            is_reboot_required_value=constants.RebootRequired.false)
 
     selectors = {'CreationClassName': cim_creation_class_name,
                  'Name': cim_name,
@@ -444,5 +416,4 @@ def set_settings(settings_type,
                         selectors, properties,
                         wait_for_idrac=wait_for_idrac)
 
-    return build_return_dict(doc, resource_uri,
-                             include_commit_required=include_commit_required)
+    return build_return_dict(doc, resource_uri)


### PR DESCRIPTION
Hey Chris,
This PR is having Implementation of code for getting raid controller mode and setting required raid controller mode in python dracclient for adding support for H740P Enhanced HBA mode.
Tested this code for H70P controller and also updated unit test cases.