### PR TITLE
changed RAIDStatus to RaidStatus with unit test-cases

### DIFF
--- a/dracclient/resources/raid.py
+++ b/dracclient/resources/raid.py
@@ -174,7 +174,12 @@ class RAIDManagement(object):
         drac_raid_level = self._get_virtual_disk_attr(drac_disk, 'RAIDTypes')
         size_b = self._get_virtual_disk_attr(drac_disk, 'SizeInBytes')
         drac_status = self._get_virtual_disk_attr(drac_disk, 'PrimaryStatus')
-        drac_raid_status = self._get_virtual_disk_attr(drac_disk, 'RAIDStatus')
+        drac_raid_status = self._get_virtual_disk_attr(
+            drac_disk, 'RAIDStatus', allow_missing=True)
+        if drac_raid_status is None:
+            drac_raid_status = self._get_virtual_disk_attr(
+                drac_disk, 'RaidStatus')
+
         drac_pending_operations = self._get_virtual_disk_attr(
             drac_disk, 'PendingOperations')
 
@@ -199,10 +204,11 @@ class RAIDManagement(object):
             physical_disks=self._get_virtual_disk_attrs(drac_disk,
                                                         'PhysicalDiskIDs'))
 
-    def _get_virtual_disk_attr(self, drac_disk, attr_name, nullable=False):
+    def _get_virtual_disk_attr(
+            self, drac_disk, attr_name, nullable=False, allow_missing=False):
         return utils.get_wsman_resource_attr(
             drac_disk, uris.DCIM_VirtualDiskView, attr_name,
-            nullable=nullable)
+            nullable=nullable, allow_missing=allow_missing)
 
     def _get_virtual_disk_attrs(self, drac_disk, attr_name):
         return utils.get_all_wsman_resource_attrs(

--- a/dracclient/tests/test_raid.py
+++ b/dracclient/tests/test_raid.py
@@ -165,6 +165,36 @@ class ClientRAIDManagementTestCase(base.BaseTest):
     @mock.patch.object(dracclient.client.WSManClient,
                        'wait_until_idrac_is_ready', spec_set=True,
                        autospec=True)
+    def test_list_virtual_disks_with_raid_status_change(
+            self, mock_requests, mock_wait_until_idrac_is_ready):
+        expected_virtual_disk = raid.VirtualDisk(
+            id='Disk.Virtual.0:RAID.Integrated.1-1',
+            name='disk 0',
+            description='Virtual Disk 0 on Integrated RAID Controller 1',
+            controller='RAID.Integrated.1-1',
+            raid_level='1',
+            size_mb=571776,
+            status='ok',
+            raid_status='online',
+            span_depth=1,
+            span_length=2,
+            pending_operations=None,
+            physical_disks=[
+                'Disk.Bay.0:Enclosure.Internal.0-1:RAID.Integrated.1-1',
+                'Disk.Bay.1:Enclosure.Internal.0-1:RAID.Integrated.1-1'
+            ])
+
+        mock_requests.post(
+            'https://1.2.3.4:443/wsman',
+            text=test_utils.RAIDEnumerations[
+                uris.DCIM_VirtualDiskView]['Raid_Status_ok'])
+
+        self.assertIn(expected_virtual_disk,
+                      self.drac_client.list_virtual_disks())
+
+    @mock.patch.object(dracclient.client.WSManClient,
+                       'wait_until_idrac_is_ready', spec_set=True,
+                       autospec=True)
     def test_list_physical_disks(self, mock_requests,
                                  mock_wait_until_idrac_is_ready):
         expected_physical_disk = raid.PhysicalDisk(

--- a/dracclient/tests/utils.py
+++ b/dracclient/tests/utils.py
@@ -246,9 +246,11 @@ RAIDEnumerations = {
         'ok': load_wsman_xml('physical_disk_view-enum-ok')
     },
     uris.DCIM_VirtualDiskView: {
+        'Raid_Status_ok': load_wsman_xml(
+            'virtual_disk_view-enum-with-raid-status-ok'),
         'ok': load_wsman_xml('virtual_disk_view-enum-ok')
     }
-}
+   }
 
 RAIDInvocations = {
     uris.DCIM_RAIDService: {

--- a/dracclient/tests/wsman_mocks/virtual_disk_view-enum-with-raid-status-ok.xml
+++ b/dracclient/tests/wsman_mocks/virtual_disk_view-enum-with-raid-status-ok.xml
@@ -1,0 +1,55 @@
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+            xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+            xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+            xmlns:wsman="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+            xmlns:n1="http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_VirtualDiskView"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <s:Header>
+    <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+    <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</wsa:Action>
+    <wsa:RelatesTo>uuid:b182f1ee-103a-103a-8002-fd0aa2bdb228</wsa:RelatesTo>
+    <wsa:MessageID>uuid:b80f21ed-103f-103f-8992-a36fc6fe83b0</wsa:MessageID>
+  </s:Header>
+  <s:Body>
+    <wsen:EnumerateResponse>
+      <wsman:Items>
+        <n1:DCIM_VirtualDiskView>
+          <n1:BlockSizeInBytes>512</n1:BlockSizeInBytes>
+          <n1:BusProtocol>6</n1:BusProtocol>
+          <n1:Cachecade>0</n1:Cachecade>
+          <n1:DeviceDescription>Virtual Disk 0 on Integrated RAID Controller 1</n1:DeviceDescription>
+          <n1:DiskCachePolicy>1024</n1:DiskCachePolicy>
+          <n1:FQDD>Disk.Virtual.0:RAID.Integrated.1-1</n1:FQDD>
+          <n1:InstanceID>Disk.Virtual.0:RAID.Integrated.1-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20150301200527.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20150301200527.000000+000</n1:LastUpdateTime>
+          <n1:LockStatus>0</n1:LockStatus>
+          <n1:MediaType>1</n1:MediaType>
+          <n1:Name>disk 0</n1:Name>
+          <n1:ObjectStatus>0</n1:ObjectStatus>
+          <n1:OperationName>Background Intialization</n1:OperationName>
+          <n1:OperationPercentComplete>8</n1:OperationPercentComplete>
+          <n1:PendingOperations>0</n1:PendingOperations>
+          <n1:PhysicalDiskIDs>Disk.Bay.0:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:PhysicalDiskIDs>
+          <n1:PhysicalDiskIDs>Disk.Bay.1:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:PhysicalDiskIDs>
+          <n1:PrimaryStatus>1</n1:PrimaryStatus>
+          <n1:RaidStatus>2</n1:RaidStatus>
+          <n1:RAIDTypes>4</n1:RAIDTypes>
+          <n1:ReadCachePolicy>16</n1:ReadCachePolicy>
+          <n1:RemainingRedundancy>1</n1:RemainingRedundancy>
+          <n1:RollupStatus>1</n1:RollupStatus>
+          <n1:SizeInBytes>599550590976</n1:SizeInBytes>
+          <n1:SpanDepth>1</n1:SpanDepth>
+          <n1:SpanLength>2</n1:SpanLength>
+          <n1:StartingLBAinBlocks>0</n1:StartingLBAinBlocks>
+          <n1:StripeSize>128</n1:StripeSize>
+          <n1:T10PIStatus>0</n1:T10PIStatus>
+          <n1:VirtualDiskTargetID>0</n1:VirtualDiskTargetID>
+          <n1:WriteCachePolicy>2</n1:WriteCachePolicy>
+        </n1:DCIM_VirtualDiskView>
+      </wsman:Items>
+      <wsen:EnumerationContext/>
+      <wsman:EndOfSequence/>
+    </wsen:EnumerateResponse>
+  </s:Body>
+</s:Envelope>


### PR DESCRIPTION
Hi Chris,

Before adding this change to upstream dracclient, i would like to review dracclient patch by you first.
I have added 1 test case for RAIDStatus to RaidStatus fix. 

As change is in ``_parse_drac_virtual_disk`` , i think it is private method and there is no test cases for private methods. so i added test case for ``list_virtual_disks()`` which internally calls ``_parse_drac_virtual_disk``

Please let me know if any change is need to add/update.

Thanks 