### PR TITLE
Added Bus number to nvme drives

### DIFF
--- a/dracclient/resources/raid.py
+++ b/dracclient/resources/raid.py
@@ -82,7 +82,7 @@ PhysicalDisk = collections.namedtuple(
     ['id', 'description', 'controller', 'manufacturer', 'model', 'media_type',
      'interface_type', 'size_mb', 'free_size_mb', 'serial_number',
      'firmware_version', 'status', 'raid_status', 'sas_address',
-     'device_protocol'])
+     'device_protocol', 'drac_bus_number'])
 
 RAIDController = collections.namedtuple(
     'RAIDController', ['id', 'description', 'manufacturer', 'model',
@@ -259,6 +259,11 @@ class RAIDManagement(object):
                                                        uri)
         drac_bus_protocol = self._get_physical_disk_attr(drac_disk,
                                                          'BusProtocol', uri)
+        if uri == uris.DCIM_PCIeSSDView:
+            drac_bus_number = self._get_physical_disk_attr(drac_disk,
+                                                           'Bus', uri)
+        else:
+            drac_bus_number = None
 
         return PhysicalDisk(
             id=fqdd,
@@ -284,7 +289,8 @@ class RAIDManagement(object):
             device_protocol=self._get_physical_disk_attr(drac_disk,
                                                          'DeviceProtocol',
                                                          uri,
-                                                         allow_missing=True))
+                                                         allow_missing=True),
+            drac_bus_number=drac_bus_number)
 
     def _get_physical_disk_attr(self, drac_disk, attr_name, uri,
                                 allow_missing=False):

--- a/dracclient/tests/test_raid.py
+++ b/dracclient/tests/test_raid.py
@@ -59,7 +59,8 @@ class ClientRAIDManagementTestCase(base.BaseTest):
             status='ok',
             raid_status='ready',
             sas_address='500056B37789ABE3',
-            device_protocol=None)
+            device_protocol=None,
+            drac_bus_number=None)
 
         self.disk_2 = raid.PhysicalDisk(
             id='Disk.Bay.1:Enclosure.Internal.0-1:RAID.Integrated.1-1',
@@ -76,7 +77,8 @@ class ClientRAIDManagementTestCase(base.BaseTest):
             status='online',
             raid_status='ready',
             sas_address='500056B37789ABE3',
-            device_protocol=None)
+            device_protocol=None,
+            drac_bus_number=None)
 
         self.disk_3 = raid.PhysicalDisk(
             id='Disk.Bay.0:Enclosure.Internal.0-1:AHCI.Integrated.1-1',
@@ -93,7 +95,8 @@ class ClientRAIDManagementTestCase(base.BaseTest):
             status='online',
             raid_status='ready',
             sas_address='500056B37789ABE3',
-            device_protocol=None)
+            device_protocol=None,
+            drac_bus_number=None)
 
         self.disk_4 = raid.PhysicalDisk(
             id='Disk.Bay.1:Enclosure.Internal.0-1:AHCI.Integrated.1-1',
@@ -110,7 +113,8 @@ class ClientRAIDManagementTestCase(base.BaseTest):
             status='online',
             raid_status='ready',
             sas_address='500056B37789ABE3',
-            device_protocol=None)
+            device_protocol=None,
+            drac_bus_number=None)
 
     @mock.patch.object(dracclient.client.WSManClient,
                        'wait_until_idrac_is_ready', spec_set=True,
@@ -183,7 +187,8 @@ class ClientRAIDManagementTestCase(base.BaseTest):
             status='ok',
             raid_status='ready',
             sas_address='5000C5007764F409',
-            device_protocol=None)
+            device_protocol=None,
+            drac_bus_number=None)
 
         mock_requests.post(
             'https://1.2.3.4:443/wsman',
@@ -213,7 +218,8 @@ class ClientRAIDManagementTestCase(base.BaseTest):
             status='ok',
             raid_status='ready',
             sas_address='5000C5007764F409',
-            device_protocol=None)
+            device_protocol=None,
+            drac_bus_number=None)
 
         mock_requests.post(
             'https://1.2.3.4:443/wsman',
@@ -242,7 +248,8 @@ class ClientRAIDManagementTestCase(base.BaseTest):
             status='unknown',
             raid_status=None,
             sas_address=None,
-            device_protocol='NVMe-MI1.0')
+            device_protocol='NVMe-MI1.0',
+            drac_bus_number='3E')
 
         mock_requests.post(
             'https://1.2.3.4:443/wsman',

--- a/dracclient/tests/wsman_mocks/physical_disk_view-enum-ok.xml
+++ b/dracclient/tests/wsman_mocks/physical_disk_view-enum-ok.xml
@@ -200,7 +200,8 @@
           <n1:UsedSizeInBytes>0</n1:UsedSizeInBytes>
         </n1:DCIM_PhysicalDiskView>
         <n2:DCIM_PCIeSSDView>
-          <n2:BusProtocol>7</n2:BusProtocol>
+    	  <n2:BusProtocol>7</n2:BusProtocol>
+	  <n2:Bus>3E</n2:Bus>
           <n2:DeviceDescription>PCIe SSD in Slot 20 in Bay 1</n2:DeviceDescription>
           <n2:DeviceProtocol>NVMe-MI1.0</n2:DeviceProtocol>
           <n2:DriveFormFactor>2</n2:DriveFormFactor>


### PR DESCRIPTION
Hi Chris,

This patch adds `Bus` number to nvme drives.  As there was already one testcase for nvme drives. I just modified the existing testcases.
Please let me know if you want me to add more test cases or need to change anything else.

-Rachit